### PR TITLE
fix for too much groups specified error

### DIFF
--- a/kanten_logs/src/app/view.rs
+++ b/kanten_logs/src/app/view.rs
@@ -92,6 +92,8 @@ where
 {
     let text = if app.loading {
         vec![Spans::from("loading...")]
+    } else if app.too_much_groups_specified {
+        vec![Spans::from("too much groups specified. uncheck some groups...")]
     } else {
         vec![Spans::from(format!(
             "{} items found.",

--- a/kanten_logs/src/components/group_list/mod.rs
+++ b/kanten_logs/src/components/group_list/mod.rs
@@ -1,5 +1,6 @@
 use std::collections::BTreeSet;
 use tui::widgets::ListState;
+use crate::app;
 
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 
@@ -25,6 +26,7 @@ impl GroupList {
                 .iter()
                 .filter(|name| re.is_match(name))
                 .cloned()
+                .take(app::SPECIFIABLE_GROUPS_COUNT)
                 .collect()
         } else {
             BTreeSet::new()

--- a/kanten_logs/src/components/group_list/mod.rs
+++ b/kanten_logs/src/components/group_list/mod.rs
@@ -29,7 +29,7 @@ impl GroupList {
         } else {
             BTreeSet::new()
         };
-        let filtered: Vec<String> = selected.iter().cloned().collect();
+        let filtered: Vec<String> = items.clone();
         state.select(Some(0));
 
         GroupList {

--- a/kanten_logs/src/main.rs
+++ b/kanten_logs/src/main.rs
@@ -102,9 +102,9 @@ impl AsyncTask for Service {
                 log::debug!("start query");
                 let query_id = self
                     .client
-                    .start_default_query(input)
+                    .start_default_query(input.clone())
                     .await
-                    .expect("Failed to start query");
+                    .expect(&format!("Failed to start query {:?}", input));
                 Some(Message::StartQueryComplete(query_id))
             }
             Message::StopQueryRequest(query_id) => {


### PR DESCRIPTION
## What does this change?

Fixed the error not to occur when there are 20 or more groups even if the default filter is applied.

```
thread 'tokio-runtime-worker' panicked at 'Failed to start query: InvalidParameterException: Too many log groups specified (Service: AWSLogs; Status Code: 400; Error Code: InvalidParameterException; Request ID: 906be4b9-d392-43da-af6d-a7b0ed6f29fc; Proxy: null)
```
## References

The list of log groups to be queried. You can include up to 20 log groups.
See also https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_StartQuery.html

## What can I check for bug fixes?

・I have confirmed that the initial selection number is 20 when there are 20 or more groups even if the default filter is applied.
・I have confirmed that a message is displayed at the bottom of the view when the 21st group is selected.
![image](https://user-images.githubusercontent.com/1094339/135472571-6db2af46-e277-4bbe-bef8-82610b729f26.png)
